### PR TITLE
Trac 20774 india proxy sensu check

### DIFF
--- a/india-proxy/check-india-proxy.rb
+++ b/india-proxy/check-india-proxy.rb
@@ -128,7 +128,7 @@ class CheckIndiaProxy < Sensu::Plugin::Check::CLI
         urlx_up, urlx_error_msg = acquire_resource
       end
     rescue Timeout::Error
-      urlx_error_msg = '#{config[:host]} request timed out'
+      urlx_error_msg = "#{config[:host]}: request timed out"
     rescue => e
       urlx_error_msg = "#{config[:host]}: Request error: #{e.message}"
     end

--- a/india-proxy/check-india-proxy.rb
+++ b/india-proxy/check-india-proxy.rb
@@ -1,0 +1,167 @@
+#! /usr/bin/env ruby
+#
+#   check_india_proxy
+#
+# DESCRIPTION:
+# Alert if the India forward proxy is not working.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux, BSD
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# NOTES:
+#
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'net/http'
+require 'net/https'
+
+class CheckIndiaProxy < Sensu::Plugin::Check::CLI
+  option :critical,
+         short: '-c CRITICAL_FILE',
+         default: '/tmp/CRITICAL'
+
+  option :ua,
+         short: '-x USER-AGENT',
+         long: '--user-agent USER-AGENT',
+         description: 'Specify a USER-AGENT',
+         default: 'Sensu-HTTP-Check'
+
+  option :host,
+         short: '-h HOST',
+         long: '--hostname HOSTNAME',
+         description: 'A HOSTNAME to connect to'
+
+  option :port,
+         short: '-P PORT',
+         long: '--port PORT',
+         proc: proc(&:to_i),
+         description: 'Select another port',
+         default: 80
+
+  option :request_uri,
+         short: '-p PATH',
+         long: '--request-uri PATH',
+         description: 'Specify a uri path'
+
+  option :urla,
+         short: '-ua URL',
+         long: '--urla URL',
+         description: 'First URL to connect to'
+
+  option :urlb,
+         short: '-ub URL',
+         long: '--urlb URL',
+         description: 'Second URL to connect to'
+
+  option :timeout,
+         short: '-t SECS',
+         long: '--timeout SECS',
+         proc: proc(&:to_i),
+         description: 'Set the timeout',
+         default: 15
+
+  option :insecure,
+         short: '-k',
+         boolean: true,
+         description: 'Enabling insecure connections',
+         default: false
+
+  option :ssl,
+         short: '-s',
+         boolean: true,
+         description: 'Enabling SSL connections',
+         default: false
+
+  option :whole_response,
+         short: '-w',
+         long: '--whole-response',
+         description: 'Print whole output when check fails',
+         boolean: true,
+         default: false
+
+  def run
+    urla_up = false
+    urlb_up = false
+    urla_error_msg = ''
+    urlb_error_msg = ''
+
+    if config[:urla]
+      urla_up, urla_error_msg = check_url(config[:urla])
+    else
+      # #YELLOW
+      unknown 'No urla specified'
+    end
+
+    if config[:urlb]
+      urlb_up, urlb_error_msg = check_url(config[:urlb])
+    else
+      # #YELLOW
+      unknown 'No urlb specified'
+    end
+
+    if not(urla_up or urlb_up)
+        critical urla_error_msg + '' + urlb_error_msg
+    elsif urlb_up and not urla_up
+            warning "Bhangra is not responding but India proxy looks ok: " + urla_error_msg + '' + urlb_error_msg
+    else
+        ok urla_error_msg + '' + urlb_error_msg
+    end
+  end
+
+  def check_url(urlx)
+    uri = URI.parse(urlx)
+    config[:host] = uri.host
+    config[:port] = uri.port
+    config[:request_uri] = uri.request_uri
+    config[:ssl] = uri.scheme == 'https'
+    urlx_up = false
+    urlx_error_msg = ''
+
+    begin
+      timeout(config[:timeout]) do
+        urlx_up, urlx_error_msg = acquire_resource
+      end
+    rescue Timeout::Error
+      urlx_error_msg = '#{config[:host]} request timed out'
+    rescue => e
+      urlx_error_msg = "#{config[:host]}: Request error: #{e.message}"
+    end
+
+    return urlx_up, urlx_error_msg
+  end
+
+  def acquire_resource
+    http = nil
+    http = Net::HTTP.new(config[:host], config[:port])
+
+    if config[:ssl]
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if config[:insecure]
+    end
+
+    req = Net::HTTP::Get.new(config[:request_uri], 'User-Agent' => config[:ua])
+
+    res = http.request(req)
+
+    body = if config[:whole_response]
+             "\n" + res.body
+           else
+             ''
+    end
+
+    size = res.body.nil? ? '0' : res.body.size
+
+    case res.code
+    when /^2/, /^3/
+      return true, ("#{config[:host]}, #{res.code}, #{size} bytes" + body)
+    else
+      return false, ("#{config[:host]}, #{res.code}, #{size} bytes" + body)
+    end
+  end
+end

--- a/india-proxy/check-india-proxy.rb
+++ b/india-proxy/check-india-proxy.rb
@@ -52,12 +52,10 @@ class CheckIndiaProxy < Sensu::Plugin::Check::CLI
          description: 'Specify a uri path'
 
   option :urla,
-         short: '-ua URL',
          long: '--urla URL',
          description: 'First URL to connect to'
 
   option :urlb,
-         short: '-ub URL',
          long: '--urlb URL',
          description: 'Second URL to connect to'
 
@@ -112,7 +110,7 @@ class CheckIndiaProxy < Sensu::Plugin::Check::CLI
     elsif urlb_up and not urla_up
             warning "Bhangra is not responding but India proxy looks ok: " + urla_error_msg + '' + urlb_error_msg
     else
-        ok urla_error_msg + '' + urlb_error_msg
+        ok urla_error_msg + '; ' + urlb_error_msg
     end
   end
 

--- a/india-proxy/check-india-proxy.rb
+++ b/india-proxy/check-india-proxy.rb
@@ -4,6 +4,8 @@
 #
 # DESCRIPTION:
 # Alert if the India forward proxy is not working.
+# Gives a warning level alert if the check of urla fails but urlb succeeds.
+# Gives a critical level alert if neither url check succeeds.
 #
 # OUTPUT:
 #   plain text


### PR DESCRIPTION
The script is based on this one: https://github.com/sensu/sensu-community-plugins/blob/d7f987a23699bf18cb923ed68a4a434f035751d2/plugins/http/check-http.rb

Here's the local test results which are as expected:

Using india proxy for bhangra:
(david) ==> david: india-proxy$ ./check-india-proxy.rb --urla https://proxy.in.jana.io:443/transservice.aspx --urlb https://www.google.co.in -s -k
CheckIndiaProxy OK: proxy.in.jana.io, 200, 27 bytes; www.google.co.in, 200, 13410 bytes

Not using india proxy:
david: india-proxy$ ./check-india-proxy.rb --urla https://oximall/transservice.aspx --urlb https://www.google.co.in -s -k
CheckIndiaProxy WARNING: Bhangra is not responding but India proxy looks ok: oximall: Request error: Connection refused - connect(2)www.google.co.in, 200, 13440 bytes

Both urls fail:
(david) ==> david: india-proxy$ ./check-india-proxy.rb --urla https://oximall/transservice.aspx --urlb http://invas01.euronetworldwide.com -s -k
CheckIndiaProxy CRITICAL: oximall: Request error: Connection refused - connect(2)#{config[:host]} request timed out

Extra check returns 300 response:
(david) ==> david: india-proxy$ ./check-india-proxy.rb --urla https://oximall/transservice.aspx --urlb http://jana.com/garbage -s -k
CheckIndiaProxy WARNING: Bhangra is not responding but India proxy looks ok: oximall: Request error: Connection refused - connect(2)jana.com, 301, 184 bytes

Argument missing:
(david) ==> david: india-proxy$ ./check-india-proxy.rb --urla https://oximall/transservice.aspx -s -k
CheckIndiaProxy UNKNOWN: No urlb specified